### PR TITLE
Add second custom script source

### DIFF
--- a/source/nwebsec/Configuring-csp.rst
+++ b/source/nwebsec/Configuring-csp.rst
@@ -98,7 +98,7 @@ The :doc:`NWebsec.AspNetCore.Middleware` package includes CSP middleware. Here's
     {
         app.UseCsp(options => options
             .DefaultSources(s => s.Self())
-            .ScriptSources(s => s.Self().CustomSources("scripts.nwebsec.com"))
+            .ScriptSources(s => s.Self().CustomSources("scripts.nwebsec.com", "*.some-cdn.com"))
             .ReportUris(r => r.Uris("/report")));
 
             app.UseCspReportOnly(options => options


### PR DESCRIPTION
Add a second custom script source, to make it immediately clear how multiple sources are to be specified.

I first tried `.CustomSources("scripts.nwebsec.com *.some-cdn.com"))`, but that gives a `%20` in the actual header, rather than a space.